### PR TITLE
Few functions from libPhoneNumber-iOS

### DIFF
--- a/FlagPhoneNumber/FlagPhoneNumberTextField.swift
+++ b/FlagPhoneNumber/FlagPhoneNumberTextField.swift
@@ -228,6 +228,12 @@ open class FPNTextField: UITextField, UITextFieldDelegate, FPNCountryPickerDeleg
 			setFlag(for: phoneUtil.getRegionCode(for: validPhoneNumber))
 		}
 	}
+    
+    // Get Region Code e.g "KR"
+    public func getRegionCode() -> String?{
+        return phoneUtil.getRegionCode(for: nbPhoneNumber)
+    }
+    
 
 	// Private
 

--- a/FlagPhoneNumber/FlagPhoneNumberTextField.swift
+++ b/FlagPhoneNumber/FlagPhoneNumberTextField.swift
@@ -234,7 +234,19 @@ open class FPNTextField: UITextField, UITextFieldDelegate, FPNCountryPickerDeleg
         return phoneUtil.getRegionCode(for: nbPhoneNumber)
     }
     
+    // Get DialCode
+    public func getCountryCode(withPlus:Bool = true) -> String? {
+        guard let countryCode = phoneUtil.getCountryCode(forRegion: getRegionCode()) else { return nil }
+        if withPlus {
+            return String("+\(countryCode)")
+        }else{
+            return String("\(countryCode)")
+        }
+    }
+    
+    public func getCountry(){
 
+    }
 	// Private
 
 	@objc private func didEditText() {


### PR DESCRIPTION
### - Added getRegionCode Function
> Param

None

> Returns

 `String?  (e.g "KR")`

### - Added getCountryCode Function
> Param

`withPlus:Bool` default = true

> Returns 

`String? (e.g "+82")`

