### PR TITLE
The 3 additional delegates set, more below

### DIFF
--- a/Sources/FPNTextField.swift
+++ b/Sources/FPNTextField.swift
@@ -109,11 +109,16 @@ open class FPNTextField: UITextField, FPNCountryPickerDelegate, FPNDelegate {
 		setupPhoneCodeTextField()
 		setupLeftView()
 		setupCountryPicker()
-
+		
+		
+		self.delegate = self // sets itself as the delegate for the UITextFieldDelegate in line 416
+		
 		keyboardType = .phonePad
 		autocorrectionType = .no
 		addTarget(self, action: #selector(didEditText), for: .editingChanged)
 		addTarget(self, action: #selector(displayNumberKeyBoard), for: .touchDown)
+		
+		addTarget(self, action: #selector(textFieldTapped), for: .editingChanged) // **let us know when this textField is tapped
 	}
 
 	private func setupFlagButton() {
@@ -181,6 +186,9 @@ open class FPNTextField: UITextField, FPNCountryPickerDelegate, FPNDelegate {
 	}
 
 	@objc private func displayCountryKeyboard() {
+		
+		(delegate as? FPNTextFieldDelegate)?.detectWhenFlagTapped() // **let's us know when the flag is tapped
+		
 		inputView = countryPicker
 		inputAccessoryView = getToolBar(with: getCountryListBarButtonItems())
 		tintColor = .clear
@@ -196,6 +204,8 @@ open class FPNTextField: UITextField, FPNCountryPickerDelegate, FPNDelegate {
 		inputView = nil
 		inputAccessoryView = nil
 		resignFirstResponder()
+		
+		(delegate as? FPNTextFieldDelegate)?.detectWhenDoneButtonTapped() // **let's us know when the Done button is tapped
 	}
 
 	// - Public
@@ -436,4 +446,12 @@ open class FPNTextField: UITextField, FPNCountryPickerDelegate, FPNDelegate {
 	internal func fpnDidSelect(country: FPNCountry) {
 		setFlag(for: country.code)
 	}
+}
+
+extension FPNTextField: UITextFieldDelegate {
+    
+    @objc private func textFieldTapped() {
+        
+        (delegate as? FPNTextFieldDelegate)?.detectWhenTextFieldTapped()
+    }
 }


### PR DESCRIPTION
-Line 114 added:  self.delegate = self // sets itself as the UITextFieldDelegate

-Line 121 added:  addTarget(self, action: #selector(textFieldTapped), for: .editingChanged) // detects when textField is tapped set in Lines 451 - 457

-Line 190 added: (delegate as? FPNTextFieldDelegate)?.detectWhenFlagTapped()

-Line 208 added: (delegate as? FPNTextFieldDelegate)?.detectWhenDoneButtonTapped()

-Lines 451 - 457 added for the target method in lines 121
extension FPNTextField: UITextFieldDelegate {

    @objc private func textFieldTapped() {

        (delegate as? FPNTextFieldDelegate)?.detectWhenTextFieldTapped()
    }
}