### PR TITLE
Added the keyword 'public' to lines 4,5, and 6

### DIFF
--- a/Sources/FPNCountryPicker/FPNCountry.swift
+++ b/Sources/FPNCountryPicker/FPNCountry.swift
@@ -1,9 +1,9 @@
 import UIKit
 
 public struct FPNCountry {
-	var code: FPNCountryCode
-	var name: String
-	var phoneCode: String
+	public var code: FPNCountryCode
+	public var name: String
+	public var phoneCode: String
 	var flag: UIImage?
 
 	init(code: String, name: String, phoneCode: String) {


### PR DESCRIPTION
When using an instance of FPNTextField() eg. let phoneNumberTextField = FPNTextField(), you may want to save the code, name, and phoneCode to the db for future reference. In addition to having the user's phone number, declaring these as public gives you easy access to them once a selection is made inside the phoneNumberTextField

eg

phoneNumberTextField.set(phoneNumber: 1-212-555-1212)

let countryName = phoneNumberTextField.selectedCountry?.name // save the name of the user's country code US
let countryCode = phoneNumberTextField.selectedCountry?.code.rawValue //  save the name of the user's country United States
let phoneDialCode = phoneNumberTextField.selectedCountry?.phoneCode // save the prefix code +1