### PR TITLE
3 more delegate methods added to detect an action

### DIFF
--- a/Sources/FPNTextFieldDelegate.swift
+++ b/Sources/FPNTextFieldDelegate.swift
@@ -12,4 +12,10 @@ import UIKit
 public protocol FPNTextFieldDelegate: UITextFieldDelegate {
 	func fpnDidSelectCountry(name: String, dialCode: String, code: String)
 	func fpnDidValidatePhoneNumber(textField: FPNTextField, isValid: Bool)
+	
+	func detectWhenFlagIsTapped() // option to do something when the flag is tapped
+	
+	func detectWhenDoneButtonTapped() // option to do something when the Done button is tapped
+	
+	func detectWhenTextFieldTapped()  // option to do something when the instance of the fpnTextField is tapped
 }

--- a/Sources/FPNTextFieldDelegate.swift
+++ b/Sources/FPNTextFieldDelegate.swift
@@ -13,9 +13,9 @@ public protocol FPNTextFieldDelegate: UITextFieldDelegate {
 	func fpnDidSelectCountry(name: String, dialCode: String, code: String)
 	func fpnDidValidatePhoneNumber(textField: FPNTextField, isValid: Bool)
 	
-	func detectWhenFlagIsTapped() // option to do something when the Flag is tapped
+	func detectWhenFlagIsTapped() // option to do something when the flag in the fpnTextField is tapped
 	
 	func detectWhenDoneButtonTapped() // option to do something when the Done button is tapped
 	
-	func detectWhenTextFieldTapped()  // option to do something when the instance of the fpnTextField is tapped
+	func detectWhenTextFieldTapped()  // option to do something when the instance of the fpnTextField itself is tapped
 }

--- a/Sources/FPNTextFieldDelegate.swift
+++ b/Sources/FPNTextFieldDelegate.swift
@@ -13,7 +13,7 @@ public protocol FPNTextFieldDelegate: UITextFieldDelegate {
 	func fpnDidSelectCountry(name: String, dialCode: String, code: String)
 	func fpnDidValidatePhoneNumber(textField: FPNTextField, isValid: Bool)
 	
-	func detectWhenFlagIsTapped() // option to do something when the flag is tapped
+	func detectWhenFlagIsTapped() // option to do something when the Flag is tapped
 	
 	func detectWhenDoneButtonTapped() // option to do something when the Done button is tapped
 	


### PR DESCRIPTION
The FPNTextField() has 3 components that assist it when the user decides to enter their phone number:

1. tapping the flag itself triggers the pickerView to show all the flags
2. tapping the Done button on the keyboard dismisses the pickerView with all the flags
3. tapping the instance of the FPNTextField() also dismisses the pickerView with all the flags

Every UI is different, inside the my app I have an additional "NextButton" that is inside the vc that contains the FPNTextField(). 

1. When the flag is tapped, the keyboard switches from numeric to show the pickerView with all the flags, I wanted to disable the NextButton because it wouldn't make any sense to have it enabled knowing the user is in the process of choosing a country (the pickerView flags are on screen).

2. If the pickerView with the flags are on screen, when the Done button that is on top of the keyboard is tapped, I may want to enable or disable my NextButton.

3. If the pickerView with the flags are on screen, when the instance of the FPNTextField() is tapped (meaning the user is entering their phone number), I may want to enable or disable my NextButton.

All 3 of these delegate methods are set inside the FPNTextField class in the following:

func detectWhenFlagIsTapped() // set in the displayCountryKeyboard() method
	
func detectWhenDoneButtonTapped() // set in the resetKeyBoard() method
	
func detectWhenTextFieldTapped() // added inside the FPNTextField class as an additional target method's selector:
 addTarget(self, action: #selector(textFieldTapped), for: .editingChanged)