### PR TITLE
Use Apple's country flag emojis when the FPNCountry flag property is nil

### DIFF
--- a/Sources/FPNTextFieldDelegate.swift
+++ b/Sources/FPNTextFieldDelegate.swift
@@ -12,4 +12,10 @@ import UIKit
 public protocol FPNTextFieldDelegate: UITextFieldDelegate {
 	func fpnDidSelectCountry(name: String, dialCode: String, code: String)
 	func fpnDidValidatePhoneNumber(textField: FPNTextField, isValid: Bool)
+	
+	func detectWhenFlagIsTapped() // option to do something when the flag is tapped
+	
+	func detectWhenDoneButtonTapped() // option to do something when the Done button is tapped
+	
+	func detectWhenTextFieldTapped()  // option to do something when the instance of the fpnTextField is tapped
 }

--- a/Sources/FPNTextFieldDelegate.swift
+++ b/Sources/FPNTextFieldDelegate.swift
@@ -13,7 +13,7 @@ public protocol FPNTextFieldDelegate: UITextFieldDelegate {
 	func fpnDidSelectCountry(name: String, dialCode: String, code: String)
 	func fpnDidValidatePhoneNumber(textField: FPNTextField, isValid: Bool)
 	
-	func detectWhenFlagIsTapped() // option to do something when the flag is tapped
+	func detectWhenFlagIsTapped() // option to do something when the Flag is tapped
 	
 	func detectWhenDoneButtonTapped() // option to do something when the Done button is tapped
 	


### PR DESCRIPTION
```
public struct FPNCountry {
    public var code: FPNCountryCode
    public var name: String
    public var phoneCode: String
    var flag: UIImage?
    
    init(code: String, name: String, phoneCode: String) {
        self.name = name
        self.phoneCode = phoneCode
        self.code = FPNCountryCode(rawValue: code)!
        
        if let flag = UIImage(named: code, in: Bundle.FlagIcons, compatibleWith: nil) {
            self.flag = flag
        } else {
            
            let appleCountryEmojiStr = flag(from: code)
            
            if let countryFlag = appleCountryEmojiStr.image() {
                
                self.flag = countryFlag
                
            } else {
                
                self.flag = UIImage(named: "unknown", in: Bundle.FlagIcons, compatibleWith: nil)
            }
        }
    }
    
    func flag(from twoDigitCountryCode: String) -> String {
        let base : UInt32 = 127397
        var s = ""
        for v in twoDigitCountryCode.uppercased().unicodeScalars {
            s.unicodeScalars.append(UnicodeScalar(base + v.value)!)
        }
        return s
    }
}

extension String {
    
    func image() -> UIImage? {
        let size = CGSize(width: 40, height: 40)
        UIGraphicsBeginImageContextWithOptions(size, false, 0)
        UIColor.white.set()
        let rect = CGRect(origin: .zero, size: size)
        UIRectFill(CGRect(origin: .zero, size: size))
        (self as AnyObject).draw(in: rect, withAttributes: [.font: UIFont.systemFont(ofSize: 40)])
        let image = UIGraphicsGetImageFromCurrentImageContext()
        UIGraphicsEndImageContext()
        return image
    }
}
```