### PR TITLE
fix for copy pasting valid phone number

### DIFF
--- a/Sources/FPNTextField.swift
+++ b/Sources/FPNTextField.swift
@@ -343,7 +343,15 @@ open class FPNTextField: UITextField {
 					text = remove(dialCode: phoneCode, in: inputString)
 				}
 				(delegate as? FPNTextFieldDelegate)?.fpnDidValidatePhoneNumber(textField: self, isValid: true)
-			} else {
+            } else if let validPhoneNumber = getValidNumber(phoneNumber: clean(string: number)) {
+                //To handle copy paste number with country code
+                if validPhoneNumber.italianLeadingZero {
+                    text = "0\(validPhoneNumber.nationalNumber.stringValue)"
+                } else {
+                    text = validPhoneNumber.nationalNumber.stringValue
+                }
+                setFlag(countryCode: FPNCountryCode(rawValue: phoneUtil.getRegionCode(for: validPhoneNumber))!)
+            } else {
 				nbPhoneNumber = nil
 
 				if let dialCode = selectedCountry?.phoneCode {


### PR DESCRIPTION
There is an issue of copying a valid phone number with country code. The code appends the selected country code resulting in invalid number. To solve this I've copied the content of `set(phoneNumber)` to `didEditText()`.
It solves another issue where the selected country code doesn't match the code in pasted number

The code can be improved if `set(phoneNumber)` returns a boolean to wether it was a success. This helps improve client code as well since invalid numbers can then be handled better. Example use case is picking from contact picker with wrong number